### PR TITLE
Sort ddoc files

### DIFF
--- a/source/gendoc/main.d
+++ b/source/gendoc/main.d
@@ -99,6 +99,8 @@ int gendocMain(string[] args)
 				generator.generateDdoc(modmgr.dubPackages, absDir, absFile.relativePath(absDir).stripExtension);
 			}
 		}
+		import std.algorithm: sort;
+		generator.ddocFiles.sort!((a, b) => filenameCmp(a, b));
 		
 		foreach (pkg; modmgr.dubPackages)
 			generator.generate(pkg, cfg.singleFile);

--- a/source/gendoc/main.d
+++ b/source/gendoc/main.d
@@ -100,7 +100,7 @@ int gendocMain(string[] args)
 			}
 		}
 		import std.algorithm: sort;
-		generator.ddocFiles.sort!((a, b) => filenameCmp(a, b));
+		generator.ddocFiles.sort!((a, b) => filenameCmp(a, b) < 0);
 		
 		foreach (pkg; modmgr.dubPackages)
 			generator.generate(pkg, cfg.singleFile);


### PR DESCRIPTION
The list of ddoc files needs to be sorted to always bring out the same results.